### PR TITLE
Highlighting tweaks

### DIFF
--- a/_dev/shared.js
+++ b/_dev/shared.js
@@ -88,6 +88,21 @@ function zig_language_definition() {
     ],
     relevance: 0,
   };
+
+  const IDENTIFIER = {
+    variants: [
+      {
+        match: /([_a-zA-Z][_a-zA-Z0-9]*)/,
+      },
+      {
+        begin: '@"',
+        end: '"',
+        contains: [STRINGCONTENT],
+      },
+    ],
+    endsParent:true,
+  };
+
   const STRINGS = {
     className: "string",
     variants: [
@@ -140,13 +155,11 @@ function zig_language_definition() {
 
   const FUNCTION = {
     className: "function",
-    variants: [
-      {
-        beginKeywords: "fn",
-        end: "([_a-zA-Z][_a-zA-Z0-9]*)",
-        excludeBegin: true,
-      },
-    ],
+    beginKeywords: "fn",
+    end: "\\(",
+    excludeBegin: true,
+    excludeEnd: true,
+    contains: [IDENTIFIER],
     relevance: 0,
   };
 

--- a/_dev/shared.js
+++ b/_dev/shared.js
@@ -74,14 +74,15 @@ function zig_language_definition() {
   };
 
   const STRINGCONTENT = {
-    className: "string",
     variants: [
       {
         // escape
+        className: "string-escape",
         match: "\\\\([nrt'\"\\\\]|(x[0-9a-fA-F]{2})|(u\\{[0-9a-fA-F]+\\}))",
       },
       {
         // invalid string escape
+        className: "string-escape-invalid",
         match: "\\\\.",
       },
     ],

--- a/_dev/shared.js
+++ b/_dev/shared.js
@@ -5,7 +5,7 @@
 // Once done, copy this function over to common/head_tag.html
 
 function zig_language_definition() {
-    const LITERALS = {
+  const LITERALS = {
     className: "literal",
     match: "(true|false|null|undefined)",
   };

--- a/_dev/shared.js
+++ b/_dev/shared.js
@@ -188,7 +188,7 @@ function zig_language_definition() {
   };
 
   const NUMBERS = {
-    className: "numbers",
+    className: "number",
     variants: [
       {
         // Float

--- a/_dev/shared.js
+++ b/_dev/shared.js
@@ -103,6 +103,14 @@ function zig_language_definition() {
     endsParent:true,
   };
 
+  const FIELD_IDENTIFIER = {
+    className: "field-identifier",
+    begin: '\\.',
+    excludeBegin: true,
+    contains: [IDENTIFIER],
+    relevance: 0,
+  };
+
   const STRINGS = {
     className: "string",
     variants: [
@@ -192,6 +200,7 @@ function zig_language_definition() {
 
   const ZIG_DEFAULT_CONTAINS = [
     LITERALS,
+    FIELD_IDENTIFIER,
     STRINGS,
     COMMENTS,
     TYPES,

--- a/_dev/shared.js
+++ b/_dev/shared.js
@@ -50,8 +50,24 @@ function zig_language_definition() {
   };
 
   const COMMENTTAGS = {
-    className: "title",
-    match: "\\b(TODO|FIXME|XXX|NOTE)\\b:?",
+    variants: [
+      {
+        className: "comment-tag tag-todo",
+        match: "TODO",
+      },
+      {
+        className: "comment-tag tag-fixme",
+        match: "FIXME",
+      },
+      {
+        className: "comment-tag tag-xxx",
+        match: "XXX",
+      },
+      {
+        className: "comment-tag tag-note",
+        match: "NOTE",
+      },
+    ],
     relevance: 0,
   };
 

--- a/_dev/test-syntax-highlight.html
+++ b/_dev/test-syntax-highlight.html
@@ -1,5 +1,6 @@
+<!DOCTYPE html>
 <html lang="en">
-<head >
+<head>
     <title>Zig Syntax Highlighting</title>
     <meta charset="utf-8"/>
     <!--
@@ -19,10 +20,11 @@
         }
         body {
             padding: 0.4rem;
-            background-color: #222;
-            color: #ccc;
             font-size: 14px;
+            color: var(--zig-fg);
+            background: var(--zig-bg);
         }
+
         #zig_code {
             --gai-code-grid-gap: 1rem;
             display: grid;
@@ -53,7 +55,8 @@
             align-self: stretch;
             --zig-code-border: 1px dotted grey;
             --zig-code-padding: 0.4rem;
-            background-color: #222;
+            color: var(--zig-code-fg);
+            background: var(--zig-code-bg);
             padding: var(--zig-code-padding);
             border: var(--zig-code-border);
             margin: 0;
@@ -201,6 +204,15 @@ pub fn main() !void {
     // XXX NOTE TODO FIXME comment out next line to fix invalid escape
     // FIXME XXX NOTE TODO comment out next line to fix invalid escape
     const invalid_escape = "\\z \\u";
+
+    // TODO NOTE FIXME XXX this ordering makes more sense
+    // this is a normal comment
+    // TODO implement food ordering
+    // NOTE be sure to pick extras
+    // FIXME this isn't working quite right
+    // XXX something is strange here
+
+    // something is strange here XXX I just wanted to NOTE that
 
     var state: Food = .@"🍕";
     std.debug.print("ordering {any}\\n", .{state});

--- a/_dev/test-syntax-highlight.html
+++ b/_dev/test-syntax-highlight.html
@@ -30,12 +30,13 @@
             grid-template-columns: 1fr;
             grid-template-areas:
                 "code1"
-                "code2";
+                "code2"
+                "code3";
         }
         @media (min-width: 1100px) {
             #zig_code {
                 grid-template-columns: 1fr 1fr;
-                grid-template-areas: "code1 code2";
+                grid-template-areas: "code1 code2 code3";
                 gap: var(--gai-code-grid-gap);
             }
         }
@@ -44,6 +45,9 @@
         }
         #code_container_2 {
             grid-area: code2;
+        }
+        #code_container_3 {
+            grid-area: code3;
         }
         .lang-zig {
             align-self: stretch;
@@ -80,7 +84,7 @@
 <div id="zig_code">
     <pre id='code_container_1' class="lang-zig">Run this fiddle and the highlighted code will appear here.</pre>
     <pre id='code_container_2' class="lang-zig"></pre>
-
+    <pre id='code_container_3' class="lang-zig"></pre>
 </div>
 
 <script type="text/javascript" src="../_dev/shared.js"></script>
@@ -150,15 +154,80 @@ pub fn main() anyerror!void {
     const non_null_terminated_msg: [msg.len]u8 = msg.*;
     _ = printf(&non_null_terminated_msg);
 }`;
+
+    var zig_code_3 = `const print = std.debug.print;
+const std = @import("std");
+
+// code based on https://ziggit.dev/t/how-to-specialize-generic-function/2991/4
+// but made more silly with emojis to test escaping within identifiers
+
+const Food = enum {
+    @"🍕", // Pizza
+    @"\\u{1F354}", // Hamburger
+    @"🍟", // Fries
+};
+const OrderFood = struct {
+    fn @"orderFood() when state = 🍕"(x: i32) Food {
+        _ = x;
+        return .@"\\u{1F354}";
+    }
+
+    fn @"orderFood() when state = 🍔"(x: i32) Food {
+        _ = x;
+        return .@"🍟";
+    }
+
+    fn @"orderFood() when state = \\u{1F35F}"(x: i32) Food {
+        _ = x;
+        return .@"🍕";
+    }
+};
+
+fn orderFood(state: Food, x: i32) Food {
+    inline for (@typeInfo(Food).Enum.fields) |field| {
+        if (state == @field(Food, field.name)) {
+            const f = @field(OrderFood, "orderFood() when state = " ++ field.name);
+            return f(x);
+        }
+    }
+    unreachable;
+}
+
+pub fn main() !void {
+    std.debug.print("field access: {any}\\n", .{&OrderFood.@"orderFood() when state = \\u{1F35F}"});
+
+    // TODO FIXME XXX NOTE the last tag determines the color of the line
+    // NOTE TODO FIXME XXX something has gone very wrong here
+    // XXX NOTE TODO FIXME comment out next line to fix invalid escape
+    // FIXME XXX NOTE TODO comment out next line to fix invalid escape
+    const invalid_escape = "\\z \\u";
+
+    var state: Food = .@"🍕";
+    std.debug.print("ordering {any}\\n", .{state});
+    state = orderFood(state, 123);
+    std.debug.print("ordering {any}\\n", .{state});
+    state = orderFood(state, 123);
+    std.debug.print("ordering {any}\\n", .{state});
+    state = orderFood(state, 123);
+    std.debug.print("ordering {any}\\n", .{state});
+    state = orderFood(state, 123);
+    std.debug.print("ordering {any}\\n", .{state});
+}
+    `;
     if (zig_language_definition) {
         hljs.registerLanguage('zig', zig_language_definition);
     } else {
         console.log('zig_language_definition() function not defined');
     }
-    const highlighted_code_1 = hljs.highlight(zig_code_1, {language: "zig", ignoreIllegals: true })
-    const highlighted_code_2 = hljs.highlight(zig_code_2, {language: "zig", ignoreIllegals: true })
-    document.getElementById('code_container_1').innerHTML = highlighted_code_1.value;
-    document.getElementById('code_container_2').innerHTML = highlighted_code_2.value;
+
+    function highlight_it(code, container) {
+const result = hljs.highlight(code, {language: "zig", ignoreIllegals: true });
+document.getElementById(container).innerHTML = result.value;
+    }
+
+    highlight_it(zig_code_1, 'code_container_1');
+    highlight_it(zig_code_2, 'code_container_2');
+    highlight_it(zig_code_3, 'code_container_3');
 </script>
 </body>
 </html>

--- a/common/color_definitions.scss
+++ b/common/color_definitions.scss
@@ -1,0 +1,34 @@
+
+// combines the values from commo.scss from the light mode and dark mode, letting discourse choose
+:root {
+  --zig-fg: #{dark-light-choose(unquote("inherit"), unquote("#ccc"))};
+  --zig-bg: #{dark-light-choose(unquote("inherit"), unquote("#232323"))};
+
+  --zig-code-fg: #{dark-light-choose(unquote("inherit"), unquote("#c7c7c7"))};
+  --zig-code-bg: #{dark-light-choose(unquote("#f9f9f9"), unquote("#3c3c3c"))};
+
+  --zig-keyword: #{dark-light-choose(unquote("#333"), unquote("#ccc"))};
+  --zig-literal: #{dark-light-choose(unquote("#005C5C"), unquote("#ff8080"))};
+  --zig-built-in: #{dark-light-choose(unquote("#005C7A"), unquote("#ff894c"))};
+  --zig-operator: var(--zig-code-fg);
+  --zig-type: #{dark-light-choose(unquote("#458"), unquote("#68f"))};
+  --zig-function: #{dark-light-choose(unquote("#900"), unquote("#b1a0f8"))};
+  --zig-function-fw: #{dark-light-choose(unquote("bold"), unquote("normal"))};
+  --zig-number: var(--zig-literal);
+  --zig-field-identifier: var(--zig-code-fg);
+
+  --zig-string: #{dark-light-choose(unquote("#d14"), unquote("#2e5"))};
+  --zig-string-escape-invalid: black;
+  --zig-string-escape-invalid-bg: #ff5050;
+
+  --zig-comment: #{dark-light-choose(unquote("#545454"), unquote("#aa7"))};
+  --zig-comment-tag-todo: #{dark-light-choose(unquote("#cc4015"), unquote("#ff8a66"))};
+  --zig-comment-tag-todo-bg: inherit;
+  --zig-comment-tag-fixme: #ff4911;
+  --zig-comment-tag-fixme-bg: black;
+  --zig-comment-tag-xxx: black;
+  --zig-comment-tag-xxx-bg: #ff4911;
+  --zig-comment-tag-note: #{dark-light-choose(unquote("inherit"), unquote("#ffdb50"))};
+  --zig-comment-tag-note-bg: #{dark-light-choose(unquote("#ffdb50"), unquote("inherit"))};
+}
+

--- a/common/common.scss
+++ b/common/common.scss
@@ -8,3 +8,5 @@
 .lang-zig .hljs-function { color: #b1a0f8; }
 .lang-zig .hljs-numbers { color: #ff8080; }
 .lang-zig .hljs-string { color: #2e5; }
+.lang-zig .hljs-string-escape { font-weight: bold; }
+.lang-zig .hljs-string-escape-invalid { color: black; background-color: #ff5050; }

--- a/common/common.scss
+++ b/common/common.scss
@@ -4,7 +4,7 @@
 .lang-zig .hljs-literal { color: #ff8080; }
 .lang-zig .hljs-comment { color: #aa7; }
 .lang-zig .hljs-built_in { color: #ff894c; }
-.lang-zig .hljs-type { color: #68f; }
+.lang-zig .hljs-type { color: #68f; font-weight: bold; }
 .lang-zig .hljs-function { color: #b1a0f8; }
 .lang-zig .hljs-numbers { color: #ff8080; }
 .lang-zig .hljs-string { color: #2e5; }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,29 +1,94 @@
 /* We do not use SASS features here to make it easier to include this file without pre-compilation in _dev/test-syntax-highlight.html */
 
-.lang-zig .hljs-keyword { font-weight: bold; }
-.lang-zig .hljs-literal { color: #ff8080; }
-.lang-zig .hljs-comment { color: #aa7; }
-.lang-zig .hljs-comment-tag { font-weight: bold; }
-.lang-zig .hljs-comment-tag.tag-todo { color: #ff8a66; }
-.lang-zig .hljs-comment-tag.tag-fixme { color: #ff4911; background-color: black; }
-.lang-zig .hljs-comment-tag.tag-xxx { color: black; background-color: #ff4911; }
-.lang-zig .hljs-comment-tag.tag-note { color: #ffdb50; }
+:root {
+  --zig-fg: inherit;
+  --zig-bg: inherit;
+
+  --zig-code-fg: inherit;
+  --zig-code-bg: #f9f9f9; // #f8f8f8;
+
+  --zig-keyword: #333;
+  --zig-literal: #005C5C;
+  --zig-built-in: #005C7A;
+  --zig-type: #458;
+  --zig-function: #900;
+  --zig-function-fw: bold;
+  --zig-number: var(--zig-literal);
+
+  --zig-string: #d14; // #156225;
+  --zig-string-escape-invalid: black;
+  --zig-string-escape-invalid-bg: #ff5050;
+
+  --zig-comment: #545454;
+  --zig-comment-tag-todo: #cc4015; // #ff8a66;
+  --zig-comment-tag-todo-bg: inherit;
+  --zig-comment-tag-fixme: #ff4911;
+  --zig-comment-tag-fixme-bg: black;
+  --zig-comment-tag-xxx: black;
+  --zig-comment-tag-xxx-bg: #ff4911;
+  --zig-comment-tag-note: inherit;
+  --zig-comment-tag-note-bg: #ffdb50;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --zig-fg: #ccc;
+    --zig-bg: #232323;
+
+    --zig-code-fg: #c7c7c7; // #ccc;
+    --zig-code-bg: #3c3c3c; // #222;
+
+    --zig-keyword: #ccc;
+    --zig-literal: #ff8080;
+    --zig-built-in: #ff894c;
+    --zig-type: #68f;
+    --zig-function: #b1a0f8;
+    --zig-function-fw: normal;
+    --zig-number: var(--zig-literal);
+
+    --zig-string: #2e5;
+    --zig-string-escape-invalid: black;
+    --zig-string-escape-invalid-bg: #ff5050;
+
+    --zig-comment: #aa7;
+    --zig-comment-tag-todo: #ff8a66;
+    --zig-comment-tag-todo-bg: inherit;
+    --zig-comment-tag-fixme: #ff4911;
+    --zig-comment-tag-fixme-bg: black;
+    --zig-comment-tag-xxx: black;
+    --zig-comment-tag-xxx-bg: #ff4911;
+    --zig-comment-tag-note: #ffdb50;
+    --zig-comment-tag-note-bg: inherit;
+  }
+}
+
+.lang-zig .hljs-keyword { color: var(--zig-keyword); font-weight: bold; }
+.lang-zig .hljs-literal { color: var(--zig-literal); }
+.lang-zig .hljs-built_in { color: var(--zig-built-in); }
+.lang-zig .hljs-type { color: var(--zig-type); font-weight: bold; }
+.lang-zig .hljs-function { color: var(--zig-function); font-weight: var(--zig-function-fw); }
+.lang-zig .hljs-number { color: var(--zig-number); }
+
+.lang-zig .hljs-string { color: var(--zig-string); }
+.lang-zig .hljs-string-escape { font-weight: bold; }
+.lang-zig .hljs-string-escape-invalid { color: var(--zig-string-escape-invalid); background: var(--zig-string-escape-invalid-bg); }
+
+.lang-zig .hljs-comment { color: var(--zig-comment); font-style: italic; }
+.lang-zig .hljs-comment-tag { font-weight: bold; font-style: normal; }
+.lang-zig .hljs-comment-tag.tag-todo  { color: var(--zig-comment-tag-todo);  background: var(--zig-comment-tag-todo-bg); }
+.lang-zig .hljs-comment-tag.tag-fixme { color: var(--zig-comment-tag-fixme); background: var(--zig-comment-tag-fixme-bg); }
+.lang-zig .hljs-comment-tag.tag-xxx   { color: var(--zig-comment-tag-xxx);   background: var(--zig-comment-tag-xxx-bg); }
+.lang-zig .hljs-comment-tag.tag-note  { color: var(--zig-comment-tag-note);  background: var(--zig-comment-tag-note-bg); }
 
 @supports(selector(:has(span))) {
 /* color comment line based on the last comment tag contained in the line */
-.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-todo:last-of-type) { color: #ff8a66; }
-.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-fixme:last-of-type) { color: #ff4911; background-color: black; }
-.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type) { color: black; background-color: #ff4911; }
-.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-note:last-of-type) { color: #ffdb50; }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-todo:last-of-type) { color: var(--zig-comment-tag-todo);  background: var(--zig-comment-tag-todo-bg); }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-fixme:last-of-type){ color: var(--zig-comment-tag-fixme); background: var(--zig-comment-tag-fixme-bg); }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type)  { color: var(--zig-comment-tag-xxx);   background: var(--zig-comment-tag-xxx-bg); }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-note:last-of-type) { color: var(--zig-comment-tag-note);  background: var(--zig-comment-tag-note-bg); }
 
-.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type) .hljs-comment-tag.tag-todo { background-color: #ff8a66; color:black; }
-.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type) .hljs-comment-tag.tag-note { background-color: #ffdb50; color:black; }
+/* override certain tags to make them more readable by inverting color and background */
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type) .hljs-comment-tag.tag-todo { background:var(--zig-comment-tag-todo); color: var(--zig-comment-tag-todo-bg); }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type) .hljs-comment-tag.tag-note { background:var(--zig-comment-tag-note); color: var(--zig-comment-tag-note-bg); }
 }
 
-.lang-zig .hljs-built_in { color: #ff894c; }
-.lang-zig .hljs-type { color: #68f; font-weight: bold; }
-.lang-zig .hljs-function { color: #b1a0f8; }
-.lang-zig .hljs-numbers { color: #ff8080; }
-.lang-zig .hljs-string { color: #2e5; }
-.lang-zig .hljs-string-escape { font-weight: bold; }
-.lang-zig .hljs-string-escape-invalid { color: black; background-color: #ff5050; }

--- a/common/common.scss
+++ b/common/common.scss
@@ -8,6 +8,18 @@
 .lang-zig .hljs-comment-tag.tag-fixme { color: #ff4911; background-color: black; }
 .lang-zig .hljs-comment-tag.tag-xxx { color: black; background-color: #ff4911; }
 .lang-zig .hljs-comment-tag.tag-note { color: #ffdb50; }
+
+@supports(selector(:has(span))) {
+/* color comment line based on the last comment tag contained in the line */
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-todo:last-of-type) { color: #ff8a66; }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-fixme:last-of-type) { color: #ff4911; background-color: black; }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type) { color: black; background-color: #ff4911; }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-note:last-of-type) { color: #ffdb50; }
+
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type) .hljs-comment-tag.tag-todo { background-color: #ff8a66; color:black; }
+.lang-zig .hljs-comment:has(> span.hljs-comment-tag.tag-xxx:last-of-type) .hljs-comment-tag.tag-note { background-color: #ffdb50; color:black; }
+}
+
 .lang-zig .hljs-built_in { color: #ff894c; }
 .lang-zig .hljs-type { color: #68f; font-weight: bold; }
 .lang-zig .hljs-function { color: #b1a0f8; }

--- a/common/common.scss
+++ b/common/common.scss
@@ -3,6 +3,11 @@
 .lang-zig .hljs-keyword { font-weight: bold; }
 .lang-zig .hljs-literal { color: #ff8080; }
 .lang-zig .hljs-comment { color: #aa7; }
+.lang-zig .hljs-comment-tag { font-weight: bold; }
+.lang-zig .hljs-comment-tag.tag-todo { color: #ff8a66; }
+.lang-zig .hljs-comment-tag.tag-fixme { color: #ff4911; background-color: black; }
+.lang-zig .hljs-comment-tag.tag-xxx { color: black; background-color: #ff4911; }
+.lang-zig .hljs-comment-tag.tag-note { color: #ffdb50; }
 .lang-zig .hljs-built_in { color: #ff894c; }
 .lang-zig .hljs-type { color: #68f; font-weight: bold; }
 .lang-zig .hljs-function { color: #b1a0f8; }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,5 +1,7 @@
 /* We do not use SASS features here to make it easier to include this file without pre-compilation in _dev/test-syntax-highlight.html */
 
+// uncomment for local testing color definitions in color_definitions.scss are based on the data below
+/*
 :root {
   --zig-fg: inherit;
   --zig-bg: inherit;
@@ -10,10 +12,12 @@
   --zig-keyword: #333;
   --zig-literal: #005C5C;
   --zig-built-in: #005C7A;
+  --zig-operator: var(--zig-code-fg);
   --zig-type: #458;
   --zig-function: #900;
   --zig-function-fw: bold;
   --zig-number: var(--zig-literal);
+  --zig-field-identifier: var(--zig-code-fg);
 
   --zig-string: #d14; // #156225;
   --zig-string-escape-invalid: black;
@@ -41,10 +45,12 @@
     --zig-keyword: #ccc;
     --zig-literal: #ff8080;
     --zig-built-in: #ff894c;
+    --zig-operator: var(--zig-code-fg);
     --zig-type: #68f;
     --zig-function: #b1a0f8;
     --zig-function-fw: normal;
     --zig-number: var(--zig-literal);
+    --zig-field-identifier: var(--zig-code-fg);
 
     --zig-string: #2e5;
     --zig-string-escape-invalid: black;
@@ -61,10 +67,12 @@
     --zig-comment-tag-note-bg: inherit;
   }
 }
+*/
 
 .lang-zig .hljs-keyword { color: var(--zig-keyword); font-weight: bold; }
 .lang-zig .hljs-literal { color: var(--zig-literal); }
 .lang-zig .hljs-built_in { color: var(--zig-built-in); }
+.lang-zig .hljs-operator { color: var(--zig-operator); font-weight: normal; }
 .lang-zig .hljs-type { color: var(--zig-type); font-weight: bold; }
 .lang-zig .hljs-function { color: var(--zig-function); font-weight: var(--zig-function-fw); }
 .lang-zig .hljs-number { color: var(--zig-number); }
@@ -79,6 +87,8 @@
 .lang-zig .hljs-comment-tag.tag-fixme { color: var(--zig-comment-tag-fixme); background: var(--zig-comment-tag-fixme-bg); }
 .lang-zig .hljs-comment-tag.tag-xxx   { color: var(--zig-comment-tag-xxx);   background: var(--zig-comment-tag-xxx-bg); }
 .lang-zig .hljs-comment-tag.tag-note  { color: var(--zig-comment-tag-note);  background: var(--zig-comment-tag-note-bg); }
+
+.lang-zig .hljs-field-identifier { color: var(--zig-field-identifier); }
 
 @supports(selector(:has(span))) {
 /* color comment line based on the last comment tag contained in the line */

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -5,7 +5,7 @@
 // Read more in README.md
 //
 function zig_language_definition() {
-    const LITERALS = {
+  const LITERALS = {
     className: "literal",
     match: "(true|false|null|undefined)",
   };
@@ -50,8 +50,24 @@ function zig_language_definition() {
   };
 
   const COMMENTTAGS = {
-    className: "title",
-    match: "\\b(TODO|FIXME|XXX|NOTE)\\b:?",
+    variants: [
+      {
+        className: "comment-tag tag-todo",
+        match: "TODO",
+      },
+      {
+        className: "comment-tag tag-fixme",
+        match: "FIXME",
+      },
+      {
+        className: "comment-tag tag-xxx",
+        match: "XXX",
+      },
+      {
+        className: "comment-tag tag-note",
+        match: "NOTE",
+      },
+    ],
     relevance: 0,
   };
 
@@ -74,19 +90,43 @@ function zig_language_definition() {
   };
 
   const STRINGCONTENT = {
-    className: "string",
     variants: [
       {
         // escape
+        className: "string-escape",
         match: "\\\\([nrt'\"\\\\]|(x[0-9a-fA-F]{2})|(u\\{[0-9a-fA-F]+\\}))",
       },
       {
         // invalid string escape
+        className: "string-escape-invalid",
         match: "\\\\.",
       },
     ],
     relevance: 0,
   };
+
+  const IDENTIFIER = {
+    variants: [
+      {
+        match: /([_a-zA-Z][_a-zA-Z0-9]*)/,
+      },
+      {
+        begin: '@"',
+        end: '"',
+        contains: [STRINGCONTENT],
+      },
+    ],
+    endsParent:true,
+  };
+
+  const FIELD_IDENTIFIER = {
+    className: "field-identifier",
+    begin: '\\.',
+    excludeBegin: true,
+    contains: [IDENTIFIER],
+    relevance: 0,
+  };
+
   const STRINGS = {
     className: "string",
     variants: [
@@ -139,18 +179,16 @@ function zig_language_definition() {
 
   const FUNCTION = {
     className: "function",
-    variants: [
-      {
-        beginKeywords: "fn",
-        end: "([_a-zA-Z][_a-zA-Z0-9]*)",
-        excludeBegin: true,
-      },
-    ],
+    beginKeywords: "fn",
+    end: "\\(",
+    excludeBegin: true,
+    excludeEnd: true,
+    contains: [IDENTIFIER],
     relevance: 0,
   };
 
   const NUMBERS = {
-    className: "numbers",
+    className: "number",
     variants: [
       {
         // Float
@@ -178,6 +216,7 @@ function zig_language_definition() {
 
   const ZIG_DEFAULT_CONTAINS = [
     LITERALS,
+    FIELD_IDENTIFIER,
     STRINGS,
     COMMENTS,
     TYPES,


### PR DESCRIPTION
This topic showed the syntax highlighting misbehaving: https://ziggit.dev/t/how-to-specialize-generic-function/2991/4?u=sze

I checked it out with inspector and saw that zigs `@"arbitrary identifier"` isn't correctly handled by the highlighter.
This post first introduces the highlighting: https://ziggit.dev/t/add-zig-syntax-highlighting/723/5?u=sze

I cloned the repo and started tweaking the highlighter.
The file [_dev/test-syntax-highlight.html](https://github.com/jecolon/discourse-highlightjs-zig/tree/main/_dev/test-syntax-highlight.html) is very useful for local testing of the highlighter.
When I wanted to step through the highlighter with the debugger I changed this line, locally to the next line,
to get a non-minified version of highlight.js:
```
<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.6.0/build/highlight.js"></script>
```
But as it turned out, it was easier to look at existing other language definitions to understand how to define things, the docs lack examples.

I kept the commits fairly small and self explanatory.
With commit [c685c6b6dadaa9ba1d8cbc2dd6174effb6323a06](https://github.com/SimonLSchlee/discourse-highlightjs-zig/commit/c685c6b6dadaa9ba1d8cbc2dd6174effb6323a06) I am not quite sure about `@supports(selector(:has(span)))` it works but maybe it should be more specific?

Overall I could use help with testing this, maybe the zig community can test it with a bunch of browsers?

Other questions are:
- color choices, are the colors I picked ok, or do we want something else?
- I like the comment tags, but maybe there is some reason to avoid adding this feature?
- What other things could/should be added?

Personally I feel like it is at a good point for a first improvement (when we are done testing).
Here is a comparison of before and after:
Old             | New
:-------------------------:|:-------------------------:
![Zig Syntax Highlighting old](https://github.com/jecolon/discourse-highlightjs-zig/assets/32989557/37cabcd6-91d4-487f-8bea-3a66021c55e4 "old") | ![Zig Syntax Highlighting new](https://github.com/jecolon/discourse-highlightjs-zig/assets/32989557/ba480074-f26d-4d7b-ba98-8e05ec6314b7 "new")

When we agree upon the changes, the code still needs to be copied from `_dev/shared.js` to `common/head_tag.html`.

---

One of the later improvements I might try, is to actually capture some of the structure to differentiate between statements, expressions, declarations and identifiers more. With that it might be possible to avoid keywords being highlighted within identifiers, but that seems like a bigger change, so I don't want to start that experiment right now.