### PR TITLE
Remove hightlighting of escape sequences from multi line strings and improve highlighting of literals

### DIFF
--- a/_dev/shared.js
+++ b/_dev/shared.js
@@ -127,7 +127,7 @@ function zig_language_definition() {
     relevance: 0,
   };
 
-  const STRINGS = {
+  const SINGLELINESTRINGS = {
     className: "string",
     variants: [
       {
@@ -140,13 +140,15 @@ function zig_language_definition() {
         begin: "\\'",
         end: "\\'",
       },
-      {
-        // Multi-line
-        begin: "\\\\\\\\",
-        end: "$",
-      },
     ],
     contains: [STRINGCONTENT],
+    relevance: 0,
+  };
+
+  const MULTILINESTRING = {
+    className: "string",
+        begin: "\\\\\\\\",
+        end: "$",
     relevance: 0,
   };
 
@@ -217,7 +219,8 @@ function zig_language_definition() {
   const ZIG_DEFAULT_CONTAINS = [
     LITERALS,
     FIELD_IDENTIFIER,
-    STRINGS,
+    SINGLELINESTRINGS,
+    MULTILINESTRING,
     COMMENTS,
     TYPES,
     FUNCTION,

--- a/_dev/shared.js
+++ b/_dev/shared.js
@@ -5,11 +5,6 @@
 // Once done, copy this function over to common/head_tag.html
 
 function zig_language_definition() {
-  const LITERALS = {
-    className: "literal",
-    match: "(true|false|null|undefined)",
-  };
-
   const KEYWORDS =
     "pub align allowzero and asm async await break catch comptime|10 const continue defer " +
     "else enum errdefer export extern false fn for if inline noalias null or orelse packed promise " +
@@ -217,7 +212,6 @@ function zig_language_definition() {
   };
 
   const ZIG_DEFAULT_CONTAINS = [
-    LITERALS,
     FIELD_IDENTIFIER,
     SINGLELINESTRINGS,
     MULTILINESTRING,
@@ -233,7 +227,10 @@ function zig_language_definition() {
   return {
     name: "Zig",
     aliases: ["zig"],
-    keywords: KEYWORDS,
+    keywords: {
+      keyword: KEYWORDS,
+      literal: "true false null undefined",
+    },
     contains: ZIG_DEFAULT_CONTAINS,
   };
 }

--- a/_dev/test-syntax-highlight.html
+++ b/_dev/test-syntax-highlight.html
@@ -150,6 +150,10 @@ pub fn main() void {
 // This is also available as std.c.printf.
 pub extern "c" fn printf(format: [*:0]const u8, ...) c_int;
 
+const gpt4_pattern =
+        \\\\'(?i:[sdmt]|ll|ve|re)|[^\\r\\n\\p{L}\\p{N}]?+\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]++[\\r\\n]*|\\s*[\\r\\n]|\\s+(?!\\S)|\\s+
+    ;
+
 pub fn main() anyerror!void {
     _ = printf("Hello, world!\\n"); // OK
 

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -127,7 +127,7 @@ function zig_language_definition() {
     relevance: 0,
   };
 
-  const STRINGS = {
+  const SINGLELINESTRINGS = {
     className: "string",
     variants: [
       {
@@ -140,13 +140,15 @@ function zig_language_definition() {
         begin: "\\'",
         end: "\\'",
       },
-      {
-        // Multi-line
-        begin: "\\\\\\\\",
-        end: "$",
-      },
     ],
     contains: [STRINGCONTENT],
+    relevance: 0,
+  };
+
+  const MULTILINESTRING = {
+    className: "string",
+        begin: "\\\\\\\\",
+        end: "$",
     relevance: 0,
   };
 
@@ -217,7 +219,8 @@ function zig_language_definition() {
   const ZIG_DEFAULT_CONTAINS = [
     LITERALS,
     FIELD_IDENTIFIER,
-    STRINGS,
+    SINGLELINESTRINGS,
+    MULTILINESTRING,
     COMMENTS,
     TYPES,
     FUNCTION,

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -5,11 +5,6 @@
 // Read more in README.md
 //
 function zig_language_definition() {
-  const LITERALS = {
-    className: "literal",
-    match: "(true|false|null|undefined)",
-  };
-
   const KEYWORDS =
     "pub align allowzero and asm async await break catch comptime|10 const continue defer " +
     "else enum errdefer export extern false fn for if inline noalias null or orelse packed promise " +
@@ -217,7 +212,6 @@ function zig_language_definition() {
   };
 
   const ZIG_DEFAULT_CONTAINS = [
-    LITERALS,
     FIELD_IDENTIFIER,
     SINGLELINESTRINGS,
     MULTILINESTRING,
@@ -233,7 +227,10 @@ function zig_language_definition() {
   return {
     name: "Zig",
     aliases: ["zig"],
-    keywords: KEYWORDS,
+    keywords: {
+      keyword: KEYWORDS,
+      literal: "true false null undefined",
+    },
     contains: ZIG_DEFAULT_CONTAINS,
   };
 }


### PR DESCRIPTION
My testing setup is bit-rotted / I forgot what I did back then, but I tested it a bit with the old setup and inspected with dev tools.